### PR TITLE
Add thor dependency

### DIFF
--- a/microgem.gemspec
+++ b/microgem.gemspec
@@ -16,4 +16,5 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  gem.add_runtime_dependency 'thor', '~> 0'
 end


### PR DESCRIPTION
After installing on ruby 2.3.0 I get a require error for thor

```
$ microgem
/Users/donaldhutchison/.rvm/rubies/ruby-2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- thor (LoadError)
    from /Users/donaldhutchison/.rvm/rubies/ruby-2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/gems/microgem-1.0.5/lib/microgem/generator.rb:3:in `<top (required)>'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/gems/microgem-1.0.5/lib/microgem.rb:2:in `require_relative'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/gems/microgem-1.0.5/lib/microgem.rb:2:in `<top (required)>'
    from /Users/donaldhutchison/.rvm/rubies/ruby-2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `require'
    from /Users/donaldhutchison/.rvm/rubies/ruby-2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:127:in `rescue in require'
    from /Users/donaldhutchison/.rvm/rubies/ruby-2.3.0/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/gems/microgem-1.0.5/bin/microgem:3:in `<top (required)>'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/bin/microgem:22:in `load'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/bin/microgem:22:in `<main>'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `eval'
    from /Users/donaldhutchison/.rvm/gems/ruby-2.3.0/bin/ruby_executable_hooks:15:in `<main>'
```

Adding thor to the gemspec makes it work
